### PR TITLE
Dev/logging

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,4 +42,4 @@ $ flake8 .
 ## Logging
 
 We use python3s `logging` library. 
-DeployHost-related logging starting with `[hostname]` is handled by a logger called `command`, other logging is handled by the `deploykit` logger.
+DeployHost-related logging starting with `[hostname]` is handled by a logger called `deploykit.command`, other logging is handled by the `deploykit` logger.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,3 +38,8 @@ and linted with flake8:
 ```console
 $ flake8 .
 ```
+
+## Logging
+
+We use python3s `logging` library. 
+DeployHost-related logging starting with `[hostname]` is handled by a logger called `command`, other logging is handled by the `deploykit` logger.

--- a/deploykit/__init__.py
+++ b/deploykit/__init__.py
@@ -28,7 +28,8 @@ from typing import (
 )
 
 
-HAS_TTY = sys.stderr.isatty()
+# https://no-color.org
+DISABLE_COLOR = not sys.stderr.isatty() or os.environ.get("NO_COLOR", "") != ""
 
 
 class CommandFormatter(logging.Formatter):
@@ -44,7 +45,7 @@ class CommandFormatter(logging.Formatter):
             colorcode = 31  # red
         if record.levelno == logging.WARN:
             colorcode = 33  # yellow
-        if not HAS_TTY or colorcode is None:
+        if DISABLE_COLOR or colorcode is None:
             return super().formatMessage(record)
         else:
             return f"\x1b[{colorcode}m{super().formatMessage(record)}\x1b[0m"
@@ -65,7 +66,7 @@ def setup_loggers() -> Tuple[logging.Logger, logging.Logger]:
     kitlog.addHandler(ch)
 
     # use specific logger for command outputs
-    cmdlog = logging.getLogger('command')
+    cmdlog = logging.getLogger('deploykit.command')
     cmdlog.setLevel(logging.INFO)
 
     ch = logging.StreamHandler()

--- a/deploykit/__init__.py
+++ b/deploykit/__init__.py
@@ -183,7 +183,9 @@ class DeployHost:
                 if len(read) == 0:
                     rlist.remove(print_fd)
                 print_buf += read.decode("utf-8")
-                if read == b"" or "\n" in print_buf:
+                if (read == b"" and len(print_buf) != 0) or "\n" in print_buf:
+                    # print and empty the print_buf, if the stream is draining,
+                    # but there is still something in the buffer or on newline.
                     lines = print_buf.rstrip("\n").split("\n")
                     for line in lines:
                         if not is_err:

--- a/deploykit/__init__.py
+++ b/deploykit/__init__.py
@@ -93,20 +93,24 @@ class DeployHost:
     def _prefix_output(
         self,
         displayed_cmd: str,
-        print_fd: Optional[IO[str]],
+        print_std_fd: Optional[IO[str]],
+        print_err_fd: Optional[IO[str]],
         stdout: Optional[IO[str]],
         stderr: Optional[IO[str]],
     ) -> Tuple[str, str]:
         rlist = []
-        if print_fd is not None:
-            rlist.append(print_fd)
+        if print_std_fd is not None:
+            rlist.append(print_std_fd)
+        if print_err_fd is not None:
+            rlist.append(print_err_fd)
         if stdout is not None:
             rlist.append(stdout)
 
         if stderr is not None:
             rlist.append(stderr)
 
-        print_buf = ""
+        print_std_buf = ""
+        print_err_buf = ""
         stdout_buf = ""
         stderr_buf = ""
 
@@ -115,7 +119,7 @@ class DeployHost:
         while len(rlist) != 0:
             r, _, _ = select.select(rlist, [], [], NO_OUTPUT_TIMEOUT)
 
-            if print_fd in r and print_fd is not None:
+            def print_from(print_fd: IO[str], print_buf: str, is_err: bool = False) -> str:
                 read = os.read(print_fd.fileno(), 4096)
                 if len(read) == 0:
                     rlist.remove(print_fd)
@@ -123,9 +127,18 @@ class DeployHost:
                 if read == b"" or "\n" in print_buf:
                     lines = print_buf.rstrip("\n").split("\n")
                     for line in lines:
-                        print(f"[{self.command_prefix}] {line}")
+                        if not is_err:
+                            self.out_logger(f"[{self.command_prefix}] {line}")
+                        else:
+                            self.err_logger(f"[{self.command_prefix} ERR] {line}")
                     print_buf = ""
                 last_output = time.time()
+                return print_buf
+
+            if print_std_fd in r and print_std_fd is not None:
+                print_std_buf = print_from(print_std_fd, print_std_buf, is_err=False)
+            if print_err_fd in r and print_err_fd is not None:
+                print_err_buf = print_from(print_err_fd, print_err_buf, is_err=True)
 
             now = time.time()
             elapsed = now - start
@@ -160,13 +173,16 @@ class DeployHost:
         check: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         with ExitStack() as stack:
-            read_fd, write_fd = (None, None)
+            read_std_fd, write_std_fd = (None, None)
+            read_err_fd, write_err_fd = (None, None)
+
             if stdout is None or stderr is None:
-                read_fd, write_fd = stack.enter_context(_pipe())
+                read_std_fd, write_std_fd = stack.enter_context(_pipe())
+                read_err_fd, write_err_fd = stack.enter_context(_pipe())
 
             if stdout is None:
                 stdout_read = None
-                stdout_write = write_fd
+                stdout_write = write_std_fd
             elif stdout == subprocess.PIPE:
                 stdout_read, stdout_write = stack.enter_context(_pipe())
             else:
@@ -174,7 +190,7 @@ class DeployHost:
 
             if stderr is None:
                 stderr_read = None
-                stderr_write = write_fd
+                stderr_write = write_err_fd
             elif stderr == subprocess.PIPE:
                 stderr_read, stderr_write = stack.enter_context(_pipe())
             else:
@@ -192,8 +208,10 @@ class DeployHost:
                 env=env,
                 cwd=cwd,
             ) as p:
-                if write_fd is not None:
-                    write_fd.close()
+                if write_std_fd is not None:
+                    write_std_fd.close()
+                if write_err_fd is not None:
+                    write_err_fd.close()
                 if stdout == subprocess.PIPE:
                     assert stdout_write is not None
                     stdout_write.close()
@@ -201,7 +219,7 @@ class DeployHost:
                     assert stderr_write is not None
                     stderr_write.close()
                 stdout_data, stderr_data = self._prefix_output(
-                    displayed_cmd, read_fd, stdout_read, stderr_read
+                    displayed_cmd, read_std_fd, read_err_fd, stdout_read, stderr_read
                 )
                 ret = p.wait()
                 if ret != 0:


### PR DESCRIPTION
This PR allows to use different printing styles for stdout and stderr of `run` and `run_local` commands. 

- Adds options to `DeployHost` and `parse_hosts` to define custom printing functions
- Adds an example how to print stdout in green and stderr in red