### PR TITLE
Dev/colorful hostnames

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,4 +42,4 @@ $ flake8 .
 ## Logging
 
 We use python3s `logging` library. 
-DeployHost-related logging starting with `[hostname]` is handled by a logger called `deploykit.command`, other logging is handled by the `deploykit` logger.
+DeployHost-related logging starting with `[hostname]` is handled by a logger called `deploykit.command`, other logging is handled by the `deploykit.main` logger.

--- a/deploykit/__init__.py
+++ b/deploykit/__init__.py
@@ -71,10 +71,11 @@ class CommandFormatter(logging.Formatter):
 
 
 def setup_loggers() -> Tuple[logging.Logger, logging.Logger]:
-    # If we also use the default logger here (logging.error etc), cmdlog
-    # messages are also posted on the default logger. To avoid this message
-    # duplication, we set up kitlog which does not post cmdlog messages.
-    kitlog = logging.getLogger('deploykit')
+    # If we use the default logger here (logging.error etc) or a logger called
+    # "deploykit", then cmdlog messages are also posted on the default logger.
+    # To avoid this message duplication, we set up a main and command logger
+    # and use a "deploykit" main logger.
+    kitlog = logging.getLogger('deploykit.main')
     kitlog.setLevel(logging.INFO)
 
     ch = logging.StreamHandler()


### PR DESCRIPTION
deploykit.command logging now has colorful hostnames. Up to 8 different colors. We start with green as first hostname color because in single-host use-cases this results in less agressive looking output (default would be red). 

see https://gist.github.com/pogobanane/95a75cdc38f0c57c9a5f0b0f14f33a22 how colorcodes match to colors in your terminal