### PR TITLE
disable ssh tests on darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "flake-parts": {
       "inputs": {
-        "nixpkgs": [
+        "nixpkgs-lib": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1661009076,
-        "narHash": "sha256-phAE40gctVygRq3G3B6LhvD7u2qdQT21xsz8DdRDYFo=",
+        "lastModified": 1665512413,
+        "narHash": "sha256-IeuXVWD+VkmdVdC3d2i7mdEWhNSEvc2GUdui09zAGpE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "850d8a76026127ef02f040fb0dcfdb8b749dd9d9",
+        "rev": "08ce9a42392cf8c7fdabf7c51069381ba5455dc7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@ python";
 
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
-    flake-parts.inputs.nixpkgs.follows = "nixpkgs";
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     nixpkgs.url = "github:NixOS/nixpkgs";
   };
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,6 +10,7 @@
 , openssh
 , bash
 , lib
+, stdenv
 }:
 
 buildPythonPackage rec {
@@ -31,6 +32,8 @@ buildPythonPackage rec {
   ];
 
   #preCheck = ''echo "sleep ...."; sleep 99999'';
+
+  disabledTests = lib.optionals stdenv.isDarwin [ "test_ssh" ];
 
   # don't swallow stdout/stderr
   pytestFlagsArray = [ "-s" ];

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,10 +41,6 @@ packages = find:
 setup_requires =
     setuptools
 
-[options.entry_points]
-console_scripts =
-    nix-update = deploykit:main
-
 [bdist_wheel]
 universal = true
 


### PR DESCRIPTION
Noticed the ssh tests fail when I ran the infra repo devshell on darwin.

`entry_points` looks like it may have been added by accident?